### PR TITLE
fix: Add input=false flag to prevent TFC blockage

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -62,6 +62,6 @@ jobs:
             
             EOF
             
-            terraform init -backend-config=backend.hcl
+            terraform init -backend-config=backend.hcl -input=false
             
-            terraform apply -auto-approve 
+            terraform apply -auto-approve -input=false

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -62,6 +62,6 @@ jobs:
             
             EOF
             
-            terraform init -backend-config=backend.hcl
+            terraform init -backend-config=backend.hcl -input=false
             
-            terraform apply -auto-approve 
+            terraform apply -auto-approve -input=false

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -62,6 +62,6 @@ jobs:
             
             EOF
             
-            terraform init -backend-config=backend.hcl
+            terraform init -backend-config=backend.hcl -input=false
             
-            terraform apply -auto-approve 
+            terraform apply -auto-approve -input=false

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -68,6 +68,6 @@ jobs:
             
             EOF
             
-            terraform init -backend-config=backend.hcl
+            terraform init -backend-config=backend.hcl -input=false
             
-            terraform destroy -auto-approve
+            terraform destroy -auto-approve -input=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,5 +60,5 @@ jobs:
             workspaces { name = "${{ secrets.LICENCEPLATE }}-${{ env.environment }}-ssp-vm" }
             EOF
             
-            terraform init -backend-config=backend.hcl
-            terraform plan
+            terraform init -backend-config=backend.hcl -input=false
+            terraform plan -input=false


### PR DESCRIPTION
# Context
We want to avoid blockage on the Terraform cloud runner. 
For that we've added on all terraform reltaed command the flag `-input=false`

## Changes
- [x] add the flag on all terraform commands : `-input=false`

## Tests
- [x] Run all the command with this flag on my local terraform