### PR TITLE
fix: Use Git_Base instead of Git_Head

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,7 +27,7 @@ jobs:
       - name: env selector
         id: identify
         run: |
-          if [ ${GITHUB_HEAD_REF} = "main" ];then export github_env='prod'; else export github_env=${GITHUB_HEAD_REF}; fi
+          if [ ${GITHUB_BASE_REF} = "main" ];then export github_env='prod'; else export github_env=${GITHUB_BASE_REF}; fi
           echo "::set-output name=github_env::${github_env}"
 
     outputs:


### PR DESCRIPTION
# Context
The use of Github environment introduce a bug in the pull request workflow.
Indeed we were looking at the Head Branch (the one from which the modification comes from) instead of the base branch (the branch in which the modification are going)

## Changes
- [x] Change from `GITHUB_HEAD_REF` to `GITHUB_BASE_REF`

## Test
- [x] Verification that the env selector is selecting the Github environment that will do the changes (see step env name) [action for prod](https://github.com/kdesao-devops/startup-sample-project-aws-virtual-machines/actions/runs/3578287969/jobs/6018270353)
- [x] Verification that the env selector is selecting the Github environment that will do the changes (see step env name) [action for dev](https://github.com/kdesao-devops/startup-sample-project-aws-virtual-machines/actions/runs/3578278693/jobs/6018249190)